### PR TITLE
feat: Use filename prefix when downloading exports

### DIFF
--- a/src/components/KeyboardToolbar.vue
+++ b/src/components/KeyboardToolbar.vue
@@ -180,18 +180,25 @@ const handleFileUpload = async (event: Event) => {
     const text = await file.text()
     const data = parseJsonString(text)
 
+    // Extract filename without extension for downloads
+    const filenameWithoutExt = file.name.replace(/\.[^/.]+$/, '')
+
     // Auto-detect format and load accordingly
     if (isInternalKleFormat(data)) {
       // Internal KLE format with meta and keys
       console.log(`Loading internal KLE format from: ${file.name}`)
+      
       keyboardStore.loadLayout(data.keys, data.meta)
       toast.showSuccess(`Internal KLE layout loaded from ${file.name}`, 'Import successful')
     } else {
       // Raw KLE format (array-based)
       console.log(`Loading raw KLE format from: ${file.name}`)
       keyboardStore.loadKLELayout(data)
+      
       toast.showSuccess(`KLE layout loaded from ${file.name}`, 'Import successful')
     }
+
+    keyboardStore.filename = filenameWithoutExt
   } catch (error) {
     console.error('Error loading file:', error)
     toast.showError(
@@ -211,7 +218,7 @@ const downloadJson = () => {
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `${keyboardStore.metadata.name || 'keyboard-layout'}.json`
+  a.download = `${keyboardStore.filename || keyboardStore.metadata.name || 'keyboard-layout'}.json`
   a.click()
   URL.revokeObjectURL(url)
 }
@@ -222,7 +229,7 @@ const downloadKleInternalJson = () => {
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `${keyboardStore.metadata.name || 'keyboard-layout'}-internal.json`
+  a.download = `${keyboardStore.filename || keyboardStore.metadata.name || 'keyboard-layout'}-internal.json`
   a.click()
   URL.revokeObjectURL(url)
 }
@@ -238,7 +245,7 @@ const downloadPng = () => {
 
     // Create a download link
     const link = document.createElement('a')
-    link.download = `${keyboardStore.metadata.name || 'keyboard-layout'}.png`
+    link.download = `${keyboardStore.filename || keyboardStore.metadata.name || 'keyboard-layout'}.png`
     link.href = canvas.toDataURL('image/png')
     link.click()
 

--- a/src/components/__tests__/KeyboardToolbar.spec.ts
+++ b/src/components/__tests__/KeyboardToolbar.spec.ts
@@ -252,5 +252,31 @@ describe('KeyboardToolbar', () => {
       const expectedFilename = `${store.metadata.name}-internal.json`
       expect(expectedFilename).toBe('Test Layout-internal.json')
     })
+
+    it('should prioritize filename over metadata name for downloads', async () => {
+      const pinia = createPinia()
+      setActivePinia(pinia)
+
+      const store = useKeyboardStore()
+
+      store.filename = 'imported-layout'
+      store.metadata.name = 'Different Layout Name'
+
+      const expectedFilename = `${store.filename || store.metadata.name || 'keyboard-layout'}.json`
+      expect(expectedFilename).toBe('imported-layout.json')
+    })
+
+    it('should fallback to metadata name when no filename is set', async () => {
+      const pinia = createPinia()
+      setActivePinia(pinia)
+
+      const store = useKeyboardStore()
+
+      store.filename = ''
+      store.metadata.name = 'Layout Name'
+
+      const expectedFilename = `${store.filename || store.metadata.name || 'keyboard-layout'}.json`
+      expect(expectedFilename).toBe('Layout Name.json')
+    })
   })
 })

--- a/src/stores/keyboard.ts
+++ b/src/stores/keyboard.ts
@@ -16,6 +16,7 @@ export interface KeyboardState {
   keys: Key[]
   selectedKeys: Key[]
   metadata: KeyboardMetadata
+  filename: string // Original filename for downloads
   clipboard: Key[]
   historyIndex: number
   history: { keys: Key[]; metadata: KeyboardMetadata }[]
@@ -48,6 +49,7 @@ export const useKeyboardStore = defineStore('keyboard', () => {
   const keys: Ref<Key[]> = ref([])
   const selectedKeys: Ref<Key[]> = ref([])
   const metadata: Ref<KeyboardMetadata> = ref(new KeyboardMetadata())
+  const filename: Ref<string> = ref('')
   const clipboard: Ref<Key[]> = ref([])
   const historyIndex = ref(-1)
   const history: Ref<
@@ -314,6 +316,7 @@ export const useKeyboardStore = defineStore('keyboard', () => {
     keys.value = []
     selectedKeys.value = []
     metadata.value = new KeyboardMetadata()
+    filename.value = ''
     history.value = []
     historyIndex.value = -1
     saveState()
@@ -930,6 +933,7 @@ export const useKeyboardStore = defineStore('keyboard', () => {
     keys,
     selectedKeys,
     metadata,
+    filename,
     clipboard,
     historyIndex,
     history,


### PR DESCRIPTION
Just like in the original KLE, if you upload 'me-file.json', you download 'me-file.png'